### PR TITLE
Accessibility Feedback

### DIFF
--- a/leaflet-control-zoombar.css
+++ b/leaflet-control-zoombar.css
@@ -16,6 +16,9 @@ div.leaflet-control-zoom button {
     height: 30px;
     color: black;
 }
+div.leaflet-control-zoom button:focus {
+  outline: 2px solid black !important;
+}
 div.leaflet-control-zoom button.leaflet-control-zoom-zoomin {
     font-size: 22px;
     font-family: monospace;


### PR DESCRIPTION
Everything was fine, just added an outline that's thicker and darker than the default one.

The focus indicator should at least be 3:1 (I do recommend higher than that) against adjacent colors and background, so feel free to update to a different design as long as the contrast is high enough.